### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -28,7 +28,7 @@ jobs:
           composer install
 
       - name: Build and publish nginx to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           ENV: prod
         with:
@@ -41,7 +41,7 @@ jobs:
           tags: "latest,${{ env.RELEASE_VERSION }}"
 
       - name: Build and publish php to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: docker.pkg.github.com
           name: optimuscrime/180-days-challenge-2022/180-days-challenge-2022-php
@@ -51,7 +51,7 @@ jobs:
           tags: "latest,${{ env.RELEASE_VERSION }}"
 
       - name: Build and publish migrations to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: docker.pkg.github.com
           name: optimuscrime/180-days-challenge-2022/180-days-challenge-2022-migrations


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore